### PR TITLE
Allow log to be wrapped 

### DIFF
--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -30,7 +30,7 @@ pub fn setup_favorite_list(app: &GPSApp) {
         .builder
         .object("treeview-favorites")
         .expect("Couldn't get treeview-favorites");
-    treeview::add_column_to_treeview(app, "treeview-favorites", "Name", 0);
+    treeview::add_column_to_treeview(app, "treeview-favorites", "Name", 0, false);
     reset_favorite_list(&favorite_list);
     let app_weak = app.downgrade();
     favorite_list.connect_row_activated(move |tree_view, _tree_path, _tree_column| {
@@ -119,7 +119,7 @@ pub fn setup_elements_list(app: &GPSApp) {
         .builder
         .object("treeview-elements")
         .expect("Couldn't get treeview-elements");
-    treeview::add_column_to_treeview(app, "treeview-elements", "Name", 0);
+    treeview::add_column_to_treeview(app, "treeview-elements", "Name", 0, false);
     reset_elements_list(&tree);
     let app_weak = app.downgrade();
     tree.connect_row_activated(move |tree_view, _tree_path, _tree_column| {

--- a/src/ui/logger.rs
+++ b/src/ui/logger.rs
@@ -22,9 +22,9 @@ fn reset_logger_list(logger_list: &TreeView) {
 }
 
 pub fn setup_logger_list(app: &GPSApp) {
-    treeview::add_column_to_treeview(app, "treeview-logger", "TIME", 0);
-    treeview::add_column_to_treeview(app, "treeview-logger", "LEVEL", 1);
-    treeview::add_column_to_treeview(app, "treeview-logger", "LOG", 2);
+    treeview::add_column_to_treeview(app, "treeview-logger", "TIME", 0, false);
+    treeview::add_column_to_treeview(app, "treeview-logger", "LEVEL", 1, false);
+    treeview::add_column_to_treeview(app, "treeview-logger", "LOG", 2, true);
     let logger_list: TreeView = app
         .builder
         .object("treeview-logger")

--- a/src/ui/treeview.rs
+++ b/src/ui/treeview.rs
@@ -7,10 +7,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::app::GPSApp;
-use gtk::prelude::TreeViewExt;
+use gtk::prelude::{TreeViewExt, CellLayoutExt, Cast, CellRendererTextExt};
 use gtk::{CellRendererText, TreeView, TreeViewColumn};
 
-pub fn add_column_to_treeview(app: &GPSApp, tree_name: &str, column_name: &str, column_n: i32) {
+pub fn add_column_to_treeview(app: &GPSApp, tree_name: &str, column_name: &str, column_n: i32, wrappable: bool) {
     let treeview: TreeView = app
         .builder
         .object(tree_name)
@@ -21,5 +21,11 @@ pub fn add_column_to_treeview(app: &GPSApp, tree_name: &str, column_name: &str, 
     // Association of the view's column with the model's `id` column.
     column.add_attribute(&cell, "text", column_n);
     column.set_title(column_name);
+
+    if wrappable {
+        column.set_sizing(gtk::TreeViewColumnSizing::Autosize);
+        let cell: gtk::CellRendererText = column.cells()[0].clone().downcast().unwrap();
+        cell.set_wrap_width(1024);
+    }
     treeview.append_column(&column);
 }


### PR DESCRIPTION
The original layout does not allow to read the entire log message 
![image](https://user-images.githubusercontent.com/1215497/154673074-7fab1a7b-f845-4773-bf27-7326f4a1ad01.png)
